### PR TITLE
Devel2

### DIFF
--- a/src/pinochle/static/Lib/site-packages/brySVG/dragcanvas.py
+++ b/src/pinochle/static/Lib/site-packages/brySVG/dragcanvas.py
@@ -84,6 +84,7 @@ class ObjectMixin(object):
         if hittarget:
             hittarget.pointList = self.pointList
             if isinstance(self, BezierObject): hittarget.pointsetList = self.pointsetList
+            if isinstance(self, (RectangleObject, EllipseObject, ImageObject, UseObject)): hittarget.angle = self.angle
             hittarget._update()
 
     def _transformedpointlist(self, matrix):
@@ -460,8 +461,12 @@ class UseObject(svg.use, ObjectMixin):
     EITHER: `origin`: coordinates on the canvas of the point (0,0) of the object being cloned
     OR: `centre`: coordinates of the centre of the object's bounding box
     (If both are specified, the `origin` is used.)
+    `width`: required width of the object (before any rotation)
+    `height` required height of the object(before any rotation)
+    (If only one of `width` and `height` is specified, the other will be set so that the object keeps its actual aspect ratio.
+    If neither is specified, the object will be displayed at its actual size.)
     `angle`: an optional angle of rotation (clockwise, in degrees).'''
-    def __init__(self, href=None, origin=None, centre=(0,0), angle=0, objid=None):
+    def __init__(self, href=None, origin=None, centre=(0,0), width=None, height=None, angle=0, scale=None, objid=None):
         svg.use.__init__(self, href=href)
         document <= svgbase
         tempgroup = svg.g() #Needed to overcome bug in iPad getBBox implementation
@@ -470,29 +475,47 @@ class UseObject(svg.use, ObjectMixin):
         bbox = tempgroup.getBBox()
         svgbase.removeChild(tempgroup)
         document.body.removeChild(svgbase)
+        self._origwidth = bbox.width
+        self._origheight = bbox.height
+        self._origaspectratio = self._origheight/self._origwidth
         (cx, cy) = (bbox.x+bbox.width/2, bbox.y+bbox.height/2)
-        self.centre = Point((cx, cy))
-        self._width = bbox.width
-        self._height = bbox.height
-        self.originoffset = -self.centre
+        self.originoffset = Point((-cx, -cy))
+
+        if width and height:
+            (self._width, self._height) = (width, height)
+        elif width:
+            (self._width, self._height) = (width, width*self._origaspectratio)
+        elif height:
+            (self._width, self._height) = (height/self._origaspectratio, height)
+        else:
+            (self._width, self._height) = (self._origwidth, self._origheight)
+        #if self._width != 0: self.currentAspectRatio = self._height/self._width
 
         if origin:
-            self.origin = Point(origin)
-            self.centre = self.origin - self.originoffset
+            scalefactors = (self._width/self._origwidth, self._height/self._origheight)
+            self.centre = Point(origin) - self.originoffset*scalefactors
         else:
             self.centre = Point(centre)
-            self.origin = self.centre + self.originoffset
         self.angle = angle
         self.setPosition()
         if objid: self.id = objid
 
-    def setPosition(self, origin=None, centre=None, angle=None):
-        '''Move the object by changing EITHER its `origin` OR its `centre`
-        (if both are specified, the `origin` is used) OR neither.
-        The `angle` of the object can also be changed.'''
+    def setPosition(self, origin=None, centre=None, width=None, height=None, angle=None, preserveaspectratio=False):
+        '''Change the position, size, and/or angle of the object.
+        If both `origin` and `centre`are specified, the `origin` is used.
+        If only one of `width` and `height` is specified, and `preserveaspectratio` is set to `True`,
+        the other will be set so that the object keeps its current aspect ratio.'''
+        if width:
+            self._width = width
+            if preserveaspectratio and not height: self._height = width*self.currentAspectRatio
+        if height:
+            self._height = height
+            if preserveaspectratio and not width: self._width = height/self.currentAspectRatio
+        if self._width != 0: self.currentAspectRatio = self._height/self._width
+
         if origin:
-            self.origin = Point(origin)
-            self.centre = self.origin - self.originoffset
+            scalefactors = (self._width/self._origwidth, self._height/self._origheight)
+            self.centre = Point(origin) - self.originoffset*scalefactors
         elif centre:
             self.centre = Point(centre)
         if angle is not None: self.angle = angle
@@ -509,7 +532,10 @@ class UseObject(svg.use, ObjectMixin):
         [(x1, y1), (x2, y2)] = self.pointList
         (cx, cy) = ((x1+x2)/2, (y1+y2)/2)
         self.centre = Point((cx, cy))
-        self.rotatestring = self.style.transform = f"translate({cx}px,{cy}px) rotate({self.angle}deg) translate({-cx}px,{-cy}px)"
+        self.rotatestring = f"translate({cx}px,{cy}px) rotate({self.angle}deg) translate({-cx}px,{-cy}px)"
+        (xscale, yscale) = (self._width/self._origwidth, self._height/self._origheight)
+        self.scalestring = f"translate({cx}px,{cy}px) scale({xscale},{yscale}) translate({-cx}px,{-cy}px)"
+        self.style.transform = self.rotatestring + self.scalestring
         self.origin = self.centre + self.originoffset
         (self.attrs["x"], self.attrs["y"]) = self.origin
 
@@ -952,7 +978,6 @@ class Definitions(svg.defs):
 class CanvasObject(svg.svg):
     '''Wrapper for SVG svg element.  Parameters:
     width, height: NB these are the CSS properties, so can be given as percentages, or vh, vw units etc.
-                    (to set the SVG attributes which are in pixels, call canvas.setDimensions() after creating the object.)
     colour: the background colour
     objid: the DOM id
 
@@ -1111,7 +1136,7 @@ class CanvasObject(svg.svg):
         self.viewWindow = [Point((x1, y1)), Point((x2, y2))]
         return self.viewWindow
 
-    def setDimensions(self):
+    def _getDimensions(self):
         '''If the canvas was created using non-pixel dimensions (eg percentages),
         call this after adding to the page to set the SVG `width` and `height` attributes as numbers.
         Returns a tuple `(width, height)`'''
@@ -1287,7 +1312,7 @@ class CanvasObject(svg.svg):
 
     def _getScaleFactor(self):
         '''Recalculates self.scaleFactor. This is called automatically by setViewBox or fitContents().'''
-        width, height = self.setDimensions()
+        width, height = self._getDimensions()
         if width == 0 or height == 0: return 1
         vbleft, vbtop, vbwidth, vbheight = [float(x) for x in self.attrs["viewBox"].split()]
         return max(vbwidth/width, vbheight/height)
@@ -1305,7 +1330,7 @@ class CanvasObject(svg.svg):
             if hasattr(obj, "hitTarget"): continue
             if hasattr(obj, "reference"): continue # A hitTarget doesn't need its own hitTarget
             if isinstance(obj, UseObject):
-                newobj = RectangleObject(obj.pointList, obj.angle)
+                newobj = RectangleObject(pointlist=obj.pointList, angle=obj.angle)
             elif obj.style.fill != "none" or obj.fixed:
                 continue
             else:
@@ -1427,6 +1452,7 @@ class CanvasObject(svg.svg):
         self.mouseOwner.style.transform = f"translate({dx}px,{dy}px)"
         if isinstance(self.mouseOwner, [EllipseObject, RectangleObject, UseObject, ImageObject]):
             self.mouseOwner.style.transform += self.mouseOwner.rotatestring
+            if isinstance(self.mouseOwner, UseObject): self.mouseOwner.style.transform += self.mouseOwner.scalestring
 
     def _endDrag(self, event):
         self.mouseOwner.style.transform = "translate(0px,0px)"

--- a/src/pinochle/static/cardtable.py
+++ b/src/pinochle/static/cardtable.py
@@ -364,18 +364,24 @@ def display_player_meld(meld_data: str):
     data = json.loads(meld_data)
     player_name = g_player_dict[str(data["player_id"])]["name"]
     card_list = data["card_list"]
-    dialog = InfoDialog(  # pylint: disable=assignment-from-no-return
-        "Meld Score", f"{player_name}'s meld cards are:", ok=True
-    )
     try:
         xpos = 0
-        d_canvas = SVG.CanvasObject(objid="dialog_canvas")
-        dialog.panel <= d_canvas
+        d_canvas = SVG.CanvasObject("50vw", "40vh", "none", objid="dialog_canvas")
+        #dialog.panel <= d_canvas
         for card in card_list:
             d_canvas <= SVG.UseObject(href=f"#{card}", origin=(xpos, 0))
-            xpos += CARD_WIDTH / 5.0
+            xpos += CARD_WIDTH / 2.0
     except Exception as e:  # pylint: disable=invalid-name,broad-except
         mylog.warning("display_player_meld: Caught exception: %r", e)
+
+    dialog = InfoDialog(  # pylint: disable=assignment-from-no-return
+        "Meld Score",
+        html.P(f"{player_name}'s meld cards are:") + d_canvas,
+        left = 25,
+        top = 25,
+        ok=True
+    )
+    d_canvas.fitContents()
 
 
 def update_player_names(player_data: str):


### PR DESCRIPTION
First commit: After some thought and experiments I decided to add optional `width` and `height` parameters, which are available both when creating `UseObjects` and when calling `setPosition()`.  This brings `UseObjects` in line with `ImageObjects`, `RectangleObjects` and `EllipseObjects`; I thought it better to have a common interface.  Only one of `width` and `height`needs to be included when creating, because the other one will be set automatically to preserve the correct aspect ratio of the card. 

Second commit: The pop-up dialog which displays another player's meld now looks a bit tidier: "OK" is at the bottom, and the cards are displayed at full height.  However I didn't actually use the first commit when doing this - I just used `canvas.fitContents()`.  I think the `width` or `height` parameter would only be needed if you want to include cards of different sizes on the same canvas.